### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# triton-mysql
+# MySQL autopilot pattern
 
-MySQL designed for container-native deployment on Joyent's Triton platform. This repo serves as a blueprint demonstrating the Autopilot design pattern -- automatically setting up replication, backups, and failover without human intervention.
+MySQL designed for container-native deployment on Joyent's Triton platform. This repo serves as a blueprint demonstrating the autopilot design pattern -- automatically setting up replication, backups, and failover without human intervention.
 
 ---
 

--- a/common-compose.yml
+++ b/common-compose.yml
@@ -1,7 +1,7 @@
 # MySQL designed for container-native deployment on Joyent's Triton platform.
 
 mysql:
-    image: 0x74696d/triton-mysql:latest
+    image: autopilotpattern/mysql:latest
     mem_limit: 4g
     restart: always
     env_file: _env

--- a/makefile
+++ b/makefile
@@ -15,8 +15,8 @@ build:
 	docker-compose -p my -f local-compose.yml build
 
 ship:
-	docker tag -f my_mysql 0x74696d/triton-mysql
-	docker push 0x74696d/triton-mysql
+	docker tag -f my_mysql autopilotpattern/mysql
+	docker push autopilotpattern/mysql
 
 # -------------------------------------------------------
 # for testing against Docker locally


### PR DESCRIPTION
@misterbisson this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/mysql/
