### PR TITLE
Add a file lock around creation of a snapshot

### DIFF
--- a/bin/triton-mysql.py
+++ b/bin/triton-mysql.py
@@ -372,7 +372,12 @@ def on_change():
 def create_snapshot():
     log.debug('create_snapshot')
     try:
-        backup_lock = open('/tmp/{}'.format(BACKUP_TTL_KEY), 'r+')
+        lockfile_name = '/tmp/{}'.format(BACKUP_TTL_KEY)
+        backup_lock = open(lockfile_name, 'r+')
+    except IOError:
+        backup_lock = open(lockfile_name, 'w')
+
+    try:
         fcntl.flock(backup_lock, fcntl.LOCK_EX|fcntl.LOCK_NB)
 
         # we don't want .isoformat() here because of URL encoding


### PR DESCRIPTION
For https://github.com/autopilotpattern/mysql/issues/17

Because we set the "binlog isn't stale" flag at the end of a backup, a newly started cluster will spawn many `create_snapshot` processes even though we're locking the BACKUP_TTL in Consul. This adds a local file lock that prevents the node from running multiples.

Also removed an unnecessary reliance on the repl user having access to the end-user's data DB just to run health checks.

cc @misterbisson @moretea  I need to do a bit more testing on this but I think it's the right approach.