### PR TITLE
Change the $buffer substitution to include the unit (Megabyte).

### DIFF
--- a/etc/my.cnf.tmpl
+++ b/etc/my.cnf.tmpl
@@ -8,7 +8,7 @@
 # container size. Set to the amount of RAM for the most important data
 # cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
 
-innodb_buffer_pool_size = $buffer
+innodb_buffer_pool_size = ${buffer}M
 
 # Remove leading # to turn on a very important data integrity option: logging
 # changes to the binary log between backups.


### PR DESCRIPTION
The manage.py script calculates this value in Megabytes, so the
template should indicate this.  The default unit is Bytes.

Edit by @misterbisson: fixes https://github.com/autopilotpattern/mysql/issues/32