### PR TITLE
Add missing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update \
         python-dev \
         gcc \
         curl \
+        libffi-dev \
+        libssl-dev \
         percona-xtrabackup \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Those packages are needed to build the `cffi` and `cryptography` wheels.
Without them, the following errors are thrown:

```
  c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
   #include <ffi.h>
                   ^
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

  ----------------------------------------
  Failed building wheel for cffi
```

and ...

```
 build/temp.linux-x86_64-2.7/_openssl.c:423:30: fatal error: openssl/opensslv.h: No such file or directory
   #include <openssl/opensslv.h>
                                ^
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1

  ----------------------------------------
  Failed building wheel for cryptography
```