### PR TITLE
Allow custom `BACKUP_NAME` with `strftime` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following variables control the names of keys written to Consul. They are op
 - `BACKUP_TTL_KEY`: The name of the service that the backup TTL will be associated with. (Defaults to `mysql-backup-run`.)
 - `LAST_BACKUP_KEY`: The key used to store the path to the most recent backup. (Defaults to `mysql-last-backup`.)
 - `LAST_BINLOG_KEY`: The key used to store the filename of the most recent binlog file on the primary. (Defaults to `mysql-last-binlog`.)
-- `BACKUP_NAME`: Prefix for the file that's stored on Manta. (Defaults to `mysql-backup`.)
+- `BACKUP_NAME`: The name of the backup file that's stored on Manta, with optional [strftime](https://docs.python.org/2/library/time.html#time.strftime) directives. (Defaults to `mysql-backup-%Y-%m-%dT%H-%M-%SZ`.)
 - `BACKUP_TTL`: Time in seconds to wait between backups. (Defaults to `86400`, or 24 hours.)
 - `SESSION_CACHE_FILE`: The path to the on-disk cache of the Consul session ID for each node. (Defaults to `/tmp/mysql-session`.)
 - `SESSION_NAME`: The name used for session locks. (Defaults to `mysql-primary-lock`.)

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -87,7 +87,7 @@ STANDBY_KEY = get_environ('STANDBY_KEY', 'mysql-standby')
 BACKUP_TTL_KEY = get_environ('BACKUP_TTL_KEY', 'mysql-backup-run')
 LAST_BACKUP_KEY = get_environ('LAST_BACKUP_KEY', 'mysql-last-backup')
 LAST_BINLOG_KEY = get_environ('LAST_BINLOG_KEY', 'mysql-last-binlog')
-BACKUP_NAME = get_environ('BACKUP_NAME', 'mysql-backup')
+BACKUP_NAME = get_environ('BACKUP_NAME', 'mysql-backup-%Y-%m-%dT%H-%M-%SZ')
 BACKUP_TTL = '{}s'.format(get_environ('BACKUP_TTL', 86400)) # every 24 hours
 SESSION_CACHE_FILE = get_environ('SESSION_CACHE_FILE', '/tmp/mysql-session')
 SESSION_NAME = get_environ('SESSION_NAME', 'mysql-primary-lock')
@@ -455,8 +455,7 @@ def create_snapshot():
         fcntl.flock(backup_lock, fcntl.LOCK_EX|fcntl.LOCK_NB)
 
         # we don't want .isoformat() here because of URL encoding
-        now = datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%SZ')
-        backup_id = '{}-{}'.format(BACKUP_NAME, now)
+        backup_id = datetime.utcnow().strftime('{}'.format(BACKUP_NAME))
 
         with open('/tmp/backup.tar', 'w') as f:
             subprocess.check_call(['/usr/bin/innobackupex',


### PR DESCRIPTION
Defaults to the previous value that includes a timestamp, but allows the user to override it.
This is useful so that while developing locally there’s only one backup in Manta, e.g. `BACKUP_NAME=my-dev-mysql-backup` as opposed to multiple ones.