### PR TITLE
Enable environment variables expansion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ These variables will be written to `/etc/my.cnf`.
 
 - `INNODB_BUFFER_POOL_SIZE`: innodb_buffer_pool_size
 
+
+Environment variables are expanded automatically.
+This allows you to [use environment variables](https://docs.docker.com/compose/compose-file/#/environment) from the machine where `docker compose` runs.
+Example:
+
+```
+# local-compose.yml
+mysql:
+  environment:
+    USER:
+```
+
+```
+# _env
+MANTA_BUCKET=/companyaccount/stor/developers/${USER}/backups
+```
+
 ### Where to store data
 
 This pattern automates the data management and makes container effectively stateless to the Docker daemon and schedulers. This is designed to maximize convenience and reliability by minimizing the external coordination needed to manage the database. The use of external volumes (`--volumes-from`, `-v`, etc.) is not recommended.

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -470,7 +470,8 @@ def create_snapshot():
         log.info('snapshot completed, uploading to object store')
         manta_config.put_backup(backup_id, '/tmp/backup.tar')
 
-        log.debug('snapshot uploaded, setting LAST_BACKUP_KEY in Consul')
+        log.debug('snapshot uploaded to {}/{}, setting LAST_BACKUP_KEY'
+                  ' in Consul'.format(manta_config.bucket, backup_id))
         consul.kv.put(LAST_BACKUP_KEY, backup_id)
 
         ctx = dict(user=config.repl_user,

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -59,12 +59,14 @@ def debug(fn):
 
 def get_environ(key, default):
     """
-    Gets an environment variable and trims away comments and whitespace.
+    Gets an environment variable, trims away comments and whitespace,
+    and expands other environment variables.
     """
     val = os.environ.get(key, default)
     try:
         val = val.split('#')[0]
         val = val.strip()
+        val = os.path.expandvars(val)
     finally:
         # just swallow AttributeErrors for non-strings
         return val


### PR DESCRIPTION
This allows us to, for example, use env vars from the host machine where `docker-compose` runs.