### PR TITLE
Run Consul agent as co-process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM percona:5.6
 
-ENV CONTAINERPILOT_VER 2.3.0
+ENV CONTAINERPILOT_VER 2.4.0
 ENV CONTAINERPILOT file:///etc/containerpilot.json
 
 # By keeping a lot of discrete steps in a single RUN we can clean up after
@@ -31,7 +31,7 @@ RUN set -ex \
     # \
     # Add ContainerPilot and set its configuration file path \
     # \
-    && export CONTAINERPILOT_CHECKSUM=ec9dbedaca9f4a7a50762f50768cbc42879c7208 \
+    && export CONTAINERPILOT_CHECKSUM=dbdad2cd8da8fe6128f8a2d1736f7b051ba70fe6 \
     && curl -Lvo /tmp/containerpilot.tar.gz "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
     && echo "${CONTAINERPILOT_CHECKSUM}  /tmp/containerpilot.tar.gz" | sha1sum -c \
     && tar zxf /tmp/containerpilot.tar.gz -C /usr/local/bin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,48 @@
 FROM percona:5.6
 
-RUN apt-get update \
-    && apt-get install -y \
-        python \
-        python-dev \
-        gcc \
-        curl \
-        libffi-dev \
-        libssl-dev \
-        percona-xtrabackup \
-    && rm -rf /var/lib/apt/lists/*
-
-# get Python drivers MySQL, Consul, and Manta
-RUN curl -Ls -o get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python get-pip.py && \
-    pip install \
-        PyMySQL==0.6.7 \
-        python-Consul==0.4.7 \
-        manta==2.5.0 \
-        mock==2.0.0
-
-# Add ContainerPilot and set its configuration file path
-ENV CONTAINERPILOT_VER 2.0.1
+ENV CONTAINERPILOT_VER 2.3.0
 ENV CONTAINERPILOT file:///etc/containerpilot.json
-RUN export CONTAINERPILOT_CHECKSUM=a4dd6bc001c82210b5c33ec2aa82d7ce83245154 \
-    && curl -Lso /tmp/containerpilot.tar.gz \
-        "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
+
+# By keeping a lot of discrete steps in a single RUN we can clean up after
+# ourselves in the same layer. This is gross but it saves ~100MB in the image
+RUN set -ex \
+    && export buildDeps='python-dev gcc unzip' \
+    && export runDeps='python curl libffi-dev libssl-dev percona-xtrabackup ca-certificates' \
+    && apt-get update \
+    && apt-get install -y $buildDeps $runDeps --no-install-recommends \
+    # \
+    # get Python drivers MySQL, Consul, and Manta \
+    # \
+    && curl -Lvo get-pip.py https://bootstrap.pypa.io/get-pip.py \
+    && python get-pip.py \
+    && pip install \
+       PyMySQL==0.6.7 \
+       python-Consul==0.4.7 \
+       manta==2.5.0 \
+    # \
+    # Add Consul from https://releases.hashicorp.com/consul \
+    # \
+    && export CHECKSUM=abdf0e1856292468e2c9971420d73b805e93888e006c76324ae39416edcf0627 \
+    && curl -Lvo /tmp/consul.zip "https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip" \
+    && echo "${CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
+    && unzip /tmp/consul -d /usr/local/bin \
+    && rm /tmp/consul.zip \
+    && mkdir /config \
+    # \
+    # Add ContainerPilot and set its configuration file path \
+    # \
+    && export CONTAINERPILOT_CHECKSUM=ec9dbedaca9f4a7a50762f50768cbc42879c7208 \
+    && curl -Lvo /tmp/containerpilot.tar.gz "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
     && echo "${CONTAINERPILOT_CHECKSUM}  /tmp/containerpilot.tar.gz" | sha1sum -c \
     && tar zxf /tmp/containerpilot.tar.gz -C /usr/local/bin \
-    && rm /tmp/containerpilot.tar.gz
+    && rm /tmp/containerpilot.tar.gz \
+    # \
+    # clean up to minimize image layer size \
+    # \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge -y --auto-remove $buildDeps
+
+
 
 # configure ContainerPilot and MySQL
 COPY etc/* /etc/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ mysql:
     env_file: _env
     environment:
       - CONTAINERPILOT=file:///etc/containerpilot.json
+      - CONSUL_AGENT=1
 
 consul:
     image: progrium/consul:latest

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,5 +1,5 @@
 {
-  "consul": "{{ .CONSUL }}:8500",
+  "consul": "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ .CONSUL }}{{ end }}:8500",
   "preStart": "python /usr/local/bin/manage.py",
   "services": [
     {
@@ -16,5 +16,17 @@
       "poll": 10,
       "onChange": "python /usr/local/bin/manage.py on_change"
     }
+  ],
+  "coprocesses": [{{ if .CONSUL_AGENT }}
+    {
+      "command": ["/usr/local/bin/consul", "agent",
+                  "-data-dir=/data",
+                  "-config-dir=/config",
+                  "-rejoin",
+                  "-retry-join", "{{ .CONSUL }}",
+                  "-retry-max", "10",
+                  "-retry-interval", "10s"],
+      "restarts": "unlimited"
+    }{{ end }}
   ]
 }

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -5,6 +5,7 @@ mysql:
     mem_limit: 512m
     build: .
     environment:
+      - CONSUL_AGENT=1
       - CONSUL=consul
     links:
       - consul:consul

--- a/setup.sh
+++ b/setup.sh
@@ -160,6 +160,7 @@ envcheck() {
 test() {
     docker run -it --rm \
            -v $(pwd)/bin:/usr/local/bin \
+           -v $(pwd)/etc/containerpilot.json:/etc/containerpilot.json \
            -w /usr/local/bin \
            my_mysql \
            python test.py


### PR DESCRIPTION
For https://github.com/autopilotpattern/mysql/issues/43 (and https://github.com/autopilotpattern/mysql/issues/18)

Start a ContainerPilot coprocess for the Consul agent when CONSUL_AGENT is set. This Consul agent joins the raft found at the CONSUL env var. The `manage.py` application sends most Consul requests to this agent whenever it's available. During `preStart` we query the Consul raft because the co-process agent isn't running yet.

Includes:
- Updated containerpilot.json and Compose .yml files to include env variables for CONSUL_AGENT.
- Added unit test for handling the containerpilot.json template when we rewrite the ContainerPilot config after an instance becomes the primary.
- Moved a lot of the Dockerfile into a single RUN so that we can clean ourselves up without leaving extra content in the layer. (ref https://github.com/autopilotpattern/mysql/issues/18) This saves about 100MB in the image size.

This requires the work in https://github.com/joyent/containerpilot/pull/203 and we'll need to cut a ContainerPilot release with that PR in it and add it to the Dockerfile here before this can be merged.

cc @misterbisson for review.