### PR TITLE
Remove tty flag from unit-test run, for compat w/ Shippable

### DIFF
--- a/makefile
+++ b/makefile
@@ -122,7 +122,7 @@ test-local-docker:
 
 ## Run the unit tests inside the mysql container
 unit-test:
-	docker run -it --rm -w /usr/local/bin \
+	docker run --rm -w /usr/local/bin \
 		-e LOG_LEVEL=DEBUG \
 		-v $(shell pwd)/bin/manage.py:/usr/local/bin/manage.py \
 		-v $(shell pwd)/bin/test.py:/usr/local/bin/test.py \


### PR DESCRIPTION
@misterbisson this should fix the unit test runs on Shippable. (ref [build](https://app.shippable.com/runs/57c48e94c96a570f00b9e228))