### PR TITLE
Update ContainerPilot to 2.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM percona:5.6
 
-ENV CONTAINERPILOT_VER 2.4.1
+ENV CONTAINERPILOT_VER 2.4.2
 ENV CONTAINERPILOT file:///etc/containerpilot.json
 
 # By keeping a lot of discrete steps in a single RUN we can clean up after
@@ -35,7 +35,7 @@ RUN set -ex \
     # \
     # Add ContainerPilot and set its configuration file path \
     # \
-    && export CONTAINERPILOT_CHECKSUM=198d96c8d7bfafb1ab6df96653c29701510b833c \
+    && export CONTAINERPILOT_CHECKSUM=61712373d52a5cfc5ae0d694477129604a52827c \
     && curl -Lvo /tmp/containerpilot.tar.gz "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
     && echo "${CONTAINERPILOT_CHECKSUM}  /tmp/containerpilot.tar.gz" | sha1sum -c \
     && tar zxf /tmp/containerpilot.tar.gz -C /usr/local/bin \


### PR DESCRIPTION
This fixes a problem discovered during investigation of #59. 

The golang stdlib (and our `RunAndWait` implementation in ContainerPilot) has a race where if we call `Wait` after the child process has already exited and been cleaned up then an error bubbles up through the stack. This breaks the heartbeat TTL and causes the primary to be marked as unhealthy prematurely. This will aggravate the problem described in #59 (although this fix won't correct it entirely).

cc @misterbisson @jasonpincin 