### PR TITLE
Record timestamp for last snapshot rather than overloading service

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,8 @@ These variables are optional but you most likely want them:
 The following variables control the names of keys written to Consul. They are optional with sane defaults, but if you are using Consul for many other services you might have requirements to namespace keys:
 
 - `PRIMARY_KEY`: The key used to record a lock on what node is primary. (Defaults to `mysql-primary`.)
-- `STANDBY_KEY`: The key used to record a lock on what node is standby. (Defaults to `mysql-standby`.)
-- `BACKUP_TTL_KEY`: The name of the service that the backup TTL will be associated with. (Defaults to `mysql-backup-run`.)
-- `LAST_BACKUP_KEY`: The key used to store the path to the most recent backup. (Defaults to `mysql-last-backup`.)
+- `BACKUP_LOCK_KEY`: The key used to record a lock on a running snapshot. (Defaults to `mysql-backup-runninbg`.)
+- `LAST_BACKUP_KEY`: The key used to store the path and timestamp of the most recent backup. (Defaults to `mysql-last-backup`.)
 - `LAST_BINLOG_KEY`: The key used to store the filename of the most recent binlog file on the primary. (Defaults to `mysql-last-binlog`.)
 - `BACKUP_NAME`: The name of the backup file that's stored on Manta, with optional [strftime](https://docs.python.org/2/library/time.html#time.strftime) directives. (Defaults to `mysql-backup-%Y-%m-%dT%H-%M-%SZ`.)
 - `BACKUP_TTL`: Time in seconds to wait between backups. (Defaults to `86400`, or 24 hours.)

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -25,18 +25,15 @@ class Node(object):
     Node represents the state of our running container and carries
     around the MySQL config, and clients for Consul and Manta.
     """
-    def __init__(self, mysql=None, cp=None, consul=None, manta=None,
-                 name='', ip=''):
+    def __init__(self, mysql=None, cp=None, consul=None, manta=None):
         self.mysql = mysql
         self.consul = consul
         self.manta = manta
         self.cp = cp
 
-        # these fields can all be overriden for dependency injection
-        # in testing only; don't pass these args in normal operation
-        self.hostname = name if name else socket.gethostname()
-        self.name = name if name else 'mysql-{}'.format(self.hostname)
-        self.ip = ip if ip else get_ip()
+        self.hostname = socket.gethostname()
+        self.name = 'mysql-{}'.format(self.hostname)
+        self.ip = get_ip()
 
     @debug(log_output=True)
     def is_primary(self):

--- a/bin/manager/libconsul.py
+++ b/bin/manager/libconsul.py
@@ -48,28 +48,6 @@ class Consul(object):
         """ Puts a value for the key; allows all exceptions to bubble up """
         return self.client.kv.put(key, value)
 
-    def register_check(self, key, ttl):
-        """ Registers a new health check """
-        self.client.agent.check.register(
-            name=key,
-            check=pyconsul.Check.ttl(ttl),
-            check_id=key
-        )
-
-    def pass_check(self, key):
-        """ Marks an existing check as passing """
-        return self.client.agent.check.ttl_pass(key)
-
-    def is_check_healthy(self, key):
-        """ Returns whether the check for the given key is passing """
-        try:
-            check = self.client.agent.checks()[key]
-            if check['Status'] == 'passing':
-                return True
-            return False
-        except KeyError:
-            return False
-
     @debug(log_output=True)
     def get_session(self, key=SESSION_NAME, ttl=SESSION_TTL,
                     on_disk=SESSION_CACHE_FILE, cached=True):

--- a/bin/manager/libmysql.py
+++ b/bin/manager/libmysql.py
@@ -351,3 +351,10 @@ class MySQL(object):
              '--rpl-user={}:{}'.format(user, passwd),
              'failover']
         )
+
+    @debug()
+    def get_binlog(self):
+        """ Gets the current binlog file name """
+        results = self.query('show master status')
+        binlog_file = results[0]['File']
+        return binlog_file

--- a/bin/manager/utils.py
+++ b/bin/manager/utils.py
@@ -111,7 +111,7 @@ def to_flag(val):
 # env values for keys
 PRIMARY_KEY = env('PRIMARY_KEY', 'mysql-primary')
 LAST_BACKUP_KEY = env('LAST_BACKUP_KEY', 'mysql-last-backup')
-BACKUP_TTL_KEY = env('BACKUP_TTL_KEY', 'mysql-backup-run')
+BACKUP_LOCK_KEY = env('BACKUP_LOCK_KEY', 'mysql-backup-running')
 LAST_BINLOG_KEY = env('LAST_BINLOG_KEY', 'mysql-last-binlog')
 BACKUP_NAME = env('BACKUP_NAME', 'mysql-backup-%Y-%m-%dT%H-%M-%SZ')
 BACKUP_TTL = env('BACKUP_TTL', 86400, fn='{}s'.format) # every 24 hours

--- a/bin/test.py
+++ b/bin/test.py
@@ -97,8 +97,9 @@ class TestHealth(unittest.TestCase):
         temp_file = tempfile.NamedTemporaryFile()
         cp.path = temp_file.name
         my.datadir = tempfile.mkdtemp()
-        self.node = manage.Node(consul=consul, cp=cp, mysql=my,
-                                ip='192.168.1.101', name='node1')
+        self.node = manage.Node(consul=consul, cp=cp, mysql=my)
+        self.node.ip = '192.168.1.101'
+        self.node.name = 'node1'
 
     def tearDown(self):
         logging.getLogger().setLevel(logging.DEBUG)
@@ -353,8 +354,9 @@ class TestOnChange(unittest.TestCase):
         cp.path = temp_file.name
         cp.reload = mock.MagicMock(return_value=True)
 
-        self.node = manage.Node(consul=consul, cp=cp, mysql=my,
-                                ip='192.168.1.101', name='node1')
+        self.node = manage.Node(consul=consul, cp=cp, mysql=my)
+        self.node.ip = '192.168.1.101'
+        self.node.name = 'node1'
 
     def tearDown(self):
         logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
For https://github.com/autopilotpattern/mysql/issues/59

When we registered a check for the snapshot, it was not being bound to a particular service and so when it failed the check the entire node was being marked as unhealthy. Instead of further overloading the Consul services concept, we'll just write a key with the last snapshot's timestamp to Consul and then compare the timestamps against the current time and the `BACKUP_TTL` value.

cc @misterbisson @jasonpincin for review and discussion