### PR TITLE
Upgrade Consul to 0.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN set -ex \
     # \
     # Add Consul from https://releases.hashicorp.com/consul \
     # \
-    && export CHECKSUM=abdf0e1856292468e2c9971420d73b805e93888e006c76324ae39416edcf0627 \
-    && curl -Lvo /tmp/consul.zip "https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip" \
+    && export CHECKSUM=b350591af10d7d23514ebaa0565638539900cdb3aaa048f077217c4c46653dd8 \
+    && curl -Lvo /tmp/consul.zip https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip \
     && echo "${CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
-    && unzip /tmp/consul -d /usr/local/bin \
+    && unzip /tmp/consul.zip -d /usr/local/bin \
     && rm /tmp/consul.zip \
     && mkdir /config \
     # \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,13 @@ mysql:
       - LOG_LEVEL
 
 consul:
-    image: progrium/consul:latest
-    command: -server -bootstrap -ui-dir /ui
+    image: autopilotpattern/consul:0.7r0.7
+    command: >-
+      /usr/local/bin/containerpilot
+      /bin/consul agent -server
+        -bootstrap-expect 1
+        -config-dir=/etc/consul
+        -ui-dir /ui
     restart: always
     mem_limit: 128m
     ports:


### PR DESCRIPTION
For https://github.com/autopilotpattern/mysql/issues/56

This permits us to use the by-default `leave_on_terminate` option in 0.7.0 in our Consul agent.