### PR TITLE
Fix parsing of MySQL row in test rig to avoid intermittent test failures

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -153,7 +153,7 @@ class MySQLStackTest(AutopilotPatternTest):
                 got_vals = []
                 for line in results:
                     if line.startswith('field2:'):
-                        got_vals.append(line.lstrip('field2: '))
+                        got_vals.append(line.replace('field2: ', '', 1))
                     if not set(expected_vals) - set(got_vals):
                         return None # all values replicated
 


### PR DESCRIPTION
Integration tests were "randomly" failing whenever the UUID of the value we wrote to MySQL started with the "d", "e", or "f" characters because these were getting stripped off during parsing and we'd incorrectly report this as a replication failure.

cc @jasonpincin @misterbisson 
