### PR TITLE
Take advantage of failfast from autopilotpattern/testing

### DIFF
--- a/makefile
+++ b/makefile
@@ -132,7 +132,14 @@ unit-test:
 		autopilotpattern/mysql:$(TAG) \
 		python test.py
 
+## Tear down all project containers
+teardown:
+	docker-compose -p my stop
+	docker-compose -p my rm -f
+
+## Dump logs for each container to local disk
 logs:
+	docker logs my_consul_1 > consul1.log 2>&1
 	docker logs my_mysql_1 > mysql1.log 2>&1
 	docker logs my_mysql_2 > mysql2.log 2>&1
 	docker logs my_mysql_3 > mysql3.log 2>&1

--- a/setup.sh
+++ b/setup.sh
@@ -156,18 +156,8 @@ envcheck() {
     fi
 }
 
-# runs unit tests inside a Docker container
-test() {
-    docker run -it --rm \
-           -v $(pwd)/bin:/usr/local/bin \
-           -v $(pwd)/etc/containerpilot.json:/etc/containerpilot.json \
-           -w /usr/local/bin \
-           my_mysql \
-           python test.py
-}
-
 get_root_password() {
-    echo $(docker logs mysql_mysql_1 2>&1 | \
+    echo $(docker logs ${COMPOSE_PROJECT_NAME:-mysql}_mysql_1 2>&1 | \
                awk '/Generated root password/{print $NF}' | \
                awk '{$1=$1};1'
         ) | pbcopy

--- a/shippable.yml
+++ b/shippable.yml
@@ -16,8 +16,12 @@ build:
     - make unit-test
     - make test
 
+  on_failure:
+    - make teardown
+
   # send the containers to the Docker Hub
   on_success:
+    - make teardown
     - make ship
 
 integrations:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,3 +1,7 @@
+"""
+Integration tests for autopilotpattern/mysql. These tests are executed
+inside a test-running container based on autopilotpattern/testing.
+"""
 from __future__ import print_function
 import os
 from os.path import expanduser
@@ -236,4 +240,4 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         if sys.argv[1] == "unit":
             UNIT_ONLY=True
-    unittest.main()
+    unittest.main(failfast=True)


### PR DESCRIPTION
Updates the test running so that we don't tear down all our containers on a failed test run so that we can do post-mortem debugging (except on Shippable where we can't debug them anyways).

Depends on https://github.com/autopilotpattern/testing/pull/11

cc @jasonpincin @misterbisson 
