### PR TITLE
Fix Consul --retry-join failure

### DIFF
--- a/bin/manager/containerpilot.py
+++ b/bin/manager/containerpilot.py
@@ -36,16 +36,15 @@ class ContainerPilot(object):
         cfg = cfg.replace('}{{ end }}', '}')
         config = json.loads(cfg)
 
-        consul = env('CONSUL', 'consul', envs, fn='{}:8500'.format)
-
         if env('CONSUL_AGENT', False, envs, to_flag):
             config['consul'] = 'localhost:8500'
             cmd = config['coprocesses'][0]['command']
             host_cfg_idx = cmd.index('-retry-join') + 1
-            cmd[host_cfg_idx] = consul
+            cmd[host_cfg_idx] = env('CONSUL', 'consul', envs)
             config['coprocesses'][0]['command'] = cmd
         else:
-            config['consul'] = consul
+            config['consul'] = env('CONSUL', 'consul', envs,
+                                   fn='{}:8500'.format)
             config['coprocesses'] = []
 
         self.config = config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,9 @@ mysql:
       - LOG_LEVEL=INFO
 
 consul:
-    image: autopilotpattern/consul:0.7r0.7
-    command: >-
-      /usr/local/bin/containerpilot
-      /bin/consul agent -server
-        -bootstrap-expect 1
-        -config-dir=/etc/consul
-        -ui-dir /ui
+    image: consul:0.7.1
+    command: >
+      agent -server -client=0.0.0.0 -bootstrap -ui
     restart: always
     mem_limit: 128m
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ mysql:
     environment:
       - CONTAINERPILOT=file:///etc/containerpilot.json
       - CONSUL_AGENT=1
-      - LOG_LEVEL
+      - LOG_LEVEL=INFO
 
 consul:
     image: autopilotpattern/consul:0.7r0.7


### PR DESCRIPTION
This PR is for problems discovered with Consul clustering as part of debugging https://github.com/autopilotpattern/mysql/issues/71.

The Consul server was continually trying to join itself because I switched it to use autopilotpattern/consul when it's only a single-node cluster.

Also, when we reload the config for the primary, the logic in manager/containerpilot.py includes the port 8500 in the `-retry-join` field which [it should not](https://github.com/hashicorp/consul/issues/1643). So we join Consul just fine and then keep trying to re-join on a port that doesn't work after the reload.

cc @misterbisson @jasonpincin @mbbender