### PR TITLE
Upgrade ContainerPilot to 2.6.0, Consul to 0.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM percona:5.6
 
-ENV CONTAINERPILOT_VER 2.4.2
+ENV CONTAINERPILOT_VER 2.6.0
 ENV CONTAINERPILOT file:///etc/containerpilot.json
 
 # By keeping a lot of discrete steps in a single RUN we can clean up after
@@ -26,8 +26,8 @@ RUN set -ex \
     # \
     # Add Consul from https://releases.hashicorp.com/consul \
     # \
-    && export CHECKSUM=b350591af10d7d23514ebaa0565638539900cdb3aaa048f077217c4c46653dd8 \
-    && curl -Lvo /tmp/consul.zip https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip \
+    && export CHECKSUM=5dbfc555352bded8a39c7a8bf28b5d7cf47dec493bc0496e21603c84dfe41b4b \
+    && curl -Lvo /tmp/consul.zip https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_amd64.zip \
     && echo "${CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
     && unzip /tmp/consul.zip -d /usr/local/bin \
     && rm /tmp/consul.zip \
@@ -35,7 +35,7 @@ RUN set -ex \
     # \
     # Add ContainerPilot and set its configuration file path \
     # \
-    && export CONTAINERPILOT_CHECKSUM=61712373d52a5cfc5ae0d694477129604a52827c \
+    && export CONTAINERPILOT_CHECKSUM=c1bcd137fadd26ca2998eec192d04c08f62beb1f \
     && curl -Lvo /tmp/containerpilot.tar.gz "https://github.com/joyent/containerpilot/releases/download/${CONTAINERPILOT_VER}/containerpilot-${CONTAINERPILOT_VER}.tar.gz" \
     && echo "${CONTAINERPILOT_CHECKSUM}  /tmp/containerpilot.tar.gz" | sha1sum -c \
     && tar zxf /tmp/containerpilot.tar.gz -C /usr/local/bin \


### PR DESCRIPTION
This PR upgrades ContainerPilot to 2.6.0, which will move us past the health check bug fixed in 2.4.3, and upgrades Consul to 0.7.1 just to keep current with their patch set (and #73)

cc @misterbisson @jasonpincin 