### PR TITLE
Add support for defining service name in env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Pass these variables via an `_env` file. The included `setup.sh` can be used to 
 
 These variables are optional but you most likely want them:
 
+- `SERVICE_NAME`: the name by which this instance will register itself in consul. If you do not provide one, defaults to `"mysql"`.
 - `MYSQL_REPL_USER`: this user will be used on all instances to set up MySQL replication. If not set, then replication will not be set up on the replicas.
 - `MYSQL_REPL_PASSWORD`: this password will be used on all instances to set up MySQL replication. If not set, then replication will not be set up on the replicas.
 - `MYSQL_DATABASE`: create this database on startup if it doesn't already exist. The `MYSQL_USER` user will be granted superuser access to that DB.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ These variables are optional but you most likely want them:
 
 The following variables control the names of keys written to Consul. They are optional with sane defaults, but if you are using Consul for many other services you might have requirements to namespace keys:
 
-- `PRIMARY_KEY`: The key used to record a lock on what node is primary. (Defaults to `mysql-primary`.)
+- `PRIMARY_KEY`: The key used to record a lock on what node is primary. (Defaults to `${SERVICE_NAME}-primary`.)
 - `BACKUP_LOCK_KEY`: The key used to record a lock on a running snapshot. (Defaults to `mysql-backup-runninbg`.)
 - `LAST_BACKUP_KEY`: The key used to store the path and timestamp of the most recent backup. (Defaults to `mysql-last-backup`.)
 - `LAST_BINLOG_KEY`: The key used to store the filename of the most recent binlog file on the primary. (Defaults to `mysql-last-binlog`.)

--- a/bin/manager/containerpilot.py
+++ b/bin/manager/containerpilot.py
@@ -34,6 +34,10 @@ class ContainerPilot(object):
         # override the attributes directly in the resulting dict
         cfg = cfg.replace('[{{ if .CONSUL_AGENT }}', '[')
         cfg = cfg.replace('}{{ end }}', '}')
+
+        # remove templating for SERVICE_NAME
+        service_name = env('SERVICE_NAME', 'mysql')
+        cfg = cfg.replace('{{ if .SERVICE_NAME }}{{ .SERVICE_NAME }}{{ else }}mysql{{ end }}',service_name)
         config = json.loads(cfg)
 
         if env('CONSUL_AGENT', False, envs, to_flag):

--- a/bin/manager/utils.py
+++ b/bin/manager/utils.py
@@ -109,7 +109,7 @@ def to_flag(val):
 
 
 # env values for keys
-PRIMARY_KEY = env('PRIMARY_KEY', 'mysql-primary')
+PRIMARY_KEY = env('PRIMARY_KEY', env('SERVICE_NAME','mysql')+'-primary')
 LAST_BACKUP_KEY = env('LAST_BACKUP_KEY', 'mysql-last-backup')
 BACKUP_LOCK_KEY = env('BACKUP_LOCK_KEY', 'mysql-backup-running')
 LAST_BINLOG_KEY = env('LAST_BINLOG_KEY', 'mysql-last-binlog')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ mysql:
       - CONTAINERPILOT=file:///etc/containerpilot.json
       - CONSUL_AGENT=1
       - LOG_LEVEL=INFO
+      - SERVICE_NAME=mysql
 
 consul:
     image: consul:0.7.1

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -6,7 +6,7 @@
   },
   "services": [
     {
-      "name": "mysql",
+      "name": "{{ if .SERVICE_NAME }}{{ .SERVICE_NAME }}{{ else }}mysql{{ end }}",
       "port": 3306,
       "health": "python /usr/local/bin/manage.py health",
       "poll": 5,

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -15,7 +15,7 @@
   ],
   "backends": [
     {
-      "name": "mysql-primary",
+      "name": "{{ if .SERVICE_NAME }}{{ .SERVICE_NAME }}{{ else }}mysql{{ end }}-primary",
       "poll": 10,
       "onChange": "python /usr/local/bin/manage.py on_change"
     }


### PR DESCRIPTION
Per the discussion in https://github.com/joyent/containerpilot/issues/260 and @tgross request at https://github.com/joyent/containerpilot/issues/260#issuecomment-270137432

Still defaults to a service name of `"mysql"`, but can be overridden by the env var `SERVICE_NAME`.

This allows one to use the exact same image in the same environment for different services, e.g. having three mysql instances for `authdb`, 2 more for `ordersdb`, etc.

