### PR TITLE
[WIP] Correct state machine for is_primary, is_replica, UNASSIGNED.

### DIFF
--- a/bin/manage.py
+++ b/bin/manage.py
@@ -72,6 +72,12 @@ class Node(object):
         except (UnknownPrimary, ValueError) as ex:
             log.debug('could not determine primary via Consul: %s', ex)
 
+        # am I listed in the Consul PRIMARY_KEY??
+        _, primary_name = self.consul.read_lock(PRIMARY_KEY)
+        if primary_name == self.name:
+            self.cp.state = PRIMARY
+            return True
+
         self.cp.state = UNASSIGNED
         return False
 

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -77,7 +77,7 @@ class Node(object):
 
     def is_replica(self):
         """ check if we're the replica """
-        return not self.is_primary()
+        return not self.is_primary() and self.cp.state != UNASSIGNED
 
     def is_snapshot_node(self):
         """ check if we're the node that's going to execute the snapshot """

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -171,7 +171,7 @@ def on_change(node):
         log.debug('[on_change] this node is primary, no failover required.')
         if node.cp.update():
             # we're ignoring the lock here intentionally
-            node.consul.put(PRIMARY_KEY, node.hostname)
+            node.consul.put(PRIMARY_KEY, node.name)
             node.cp.reload()
         return
 
@@ -208,15 +208,15 @@ def on_change(node):
     # sure we refresh .state from mysqld/Consul
     node.cp.state = UNASSIGNED
     if node.is_primary():
-        log.info('[on_change] node %s is primary after failover', node.hostname)
+        log.info('[on_change] node %s is primary after failover', node.name)
         if node.cp.update():
             # we're intentionally ignoring the advisory lock here
-            ok = node.consul.put(PRIMARY_KEY, node.hostname)
-            log.debug('[on_change] %s obtained lock: %s', node.hostname, ok)
+            ok = node.consul.put(PRIMARY_KEY, node.name)
+            log.debug('[on_change] %s obtained lock: %s', node.name, ok)
             node.cp.reload()
         return
     elif node.is_replica():
-        log.info('[on_change] node %s is replica after failover', node.hostname)
+        log.info('[on_change] node %s is replica after failover', node.name)
 
     if node.cp.state == UNASSIGNED:
         log.error('[on_change] this node is neither primary or replica '

--- a/bin/manager/libconsul.py
+++ b/bin/manager/libconsul.py
@@ -117,6 +117,8 @@ class Consul(object):
         """
         lock = self.client.kv.get(key)
         try:
+            if not lock[1]:
+                raise KeyError
             session_lock = lock[1]['Session']
             value = lock[1]['Value']
             return session_lock, value


### PR DESCRIPTION
@tgross,

This should fix the replication issue of #71 and autopilotpattern/wordpress#42.

So far it has worked for me, but I haven't been able to run tests in my on-prem triton.

Until the PR is merged, I will keep the docker image in sync here [zeroae/mysql:i-71-replication](https://hub.docker.com/r/zeroae/mysql/tags/).