### PR TITLE
Minio Snapshotter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
     && pip install \
        python-Consul==0.7.0 \
        manta==2.5.0 \
+       minio==2.2.4 \
        mock==2.0.0 \
        json5==0.2.4 \
     # \

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -14,6 +14,7 @@ from manager.env import PRIMARY_KEY, BACKUP_NAME
 from manager.network import get_ip
 
 from manager.storage.manta_stor import Manta
+from manager.storage.minio_stor import Minio
 from manager.storage.local import Local
 
 from manager.utils import log, debug, \

--- a/bin/manage.py
+++ b/bin/manage.py
@@ -403,8 +403,11 @@ def main():
 
     my = MySQL()
 
-    if os.environ.get('SNAPSHOT_BACKEND', 'manta') == 'local':
+    snapshot_backend = os.environ.get('SNAPSHOT_BACKEND', 'manta')
+    if snapshot_backend == 'local':
         snaps = Local()
+    elif snapshot_backend == 'minio':
+        snaps = Minio()
     else:
         snaps = Manta()
 

--- a/bin/manager/storage/minio_stor.py
+++ b/bin/manager/storage/minio_stor.py
@@ -1,0 +1,45 @@
+""" Module for storing snapshots in shared local disk """
+import os
+from shutil import copyfile
+
+from manager.env import env
+from manager.utils import debug
+from minio import Minio as pyminio
+
+class Minio(object):
+    """
+
+    The Minio class wraps access to the Minio object store, where we'll put
+    our MySQL backups.
+    """
+    def __init__(self, envs=os.environ):
+        self.access_key = env('MINIO_ACCESS_KEY', None, envs)
+        self.secret_key = env('MINIO_SECRET_KEY', None, envs)
+        self.bucket = env('MINIO_BUCKET', 'backups', envs)
+        self.location = env('MINIO_LOCATION', 'us-east-1', envs)
+        self.url = env('MINIO_URL', 'minio:9000')
+        is_tls - env('MINIO_TLS_INSECURE', False, envs, fn=to_flag)
+
+        self.client = pyminio(
+            self.url,
+            access_key=self.access_key,
+            secret_key=self.secret_key,
+            secure=is_tls)
+
+        try:
+            self.client.make_bucket(self.bucket, location=self.location)
+        except:
+            raise
+
+    @debug
+    def get_backup(self, backup_id):
+        """
+        Download file from Manta, allowing exceptions to bubble up.
+        """
+        return NotImplementedError
+
+    def put_backup(self, backup_id, src):
+        """
+        Upload the backup file to the expected path.
+        """
+        return NotImplementedError

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -17,12 +17,15 @@ services:
       - BACKUP_TTL=120
       - LOG_LEVEL=DEBUG
       - CONSUL=consul
-      - SNAPSHOT_BACKEND=local
+      - SNAPSHOT_BACKEND=minio
+      - MINIO_ACCESS_KEY=supersecretaccesskey
+      - MINIO_SECRET_KEY=supersecretsecretkey
     volumes:
       # shared storage location for snapshots
       - ${WORK_DIR:-../..}/tmp:/tmp/snapshots
     links:
       - consul:consul
+      - minio:minio
 
   consul:
     image: consul:0.8.4
@@ -42,3 +45,14 @@ services:
     network_mode: bridge
     dns:
       - 127.0.0.1
+
+  minio:
+    image: minio/minio
+    command: server /export
+    restart: always
+    expose:
+      - 9000
+    network_mode: bridge
+    environment:
+      - MINIO_ACCESS_KEY=supersecretaccesskey
+      - MINIO_SECRET_KEY=supersecretsecretkey


### PR DESCRIPTION
Adds support for an S3 snapshotter via Minio. Replaces local storage in the compose example as a solution for https://github.com/autopilotpattern/mysql/issues/35.

There was also the question of whether or not we should change the name from `Minio` to S3, since it's really an S3 interface, and Minio just happens to be the preferred implementation. @tianon figured that @misterbisson or @tgross should make the call on that.